### PR TITLE
Update 01_SageMakerProcessing.Rmd

### DIFF
--- a/02_AdvancedSageMaker/01_SageMakerProcessing.Rmd
+++ b/02_AdvancedSageMaker/01_SageMakerProcessing.Rmd
@@ -15,7 +15,7 @@ rm(list = ls())
 ## Imports
 ```{r}
 suppressWarnings(library(reticulate))
-path_to_python <- "/opt/python/3.7.7/bin/python"
+path_to_python <- system("which python", intern = TRUE)
 use_python(path_to_python)
 sagemaker <- import('sagemaker')
 ```

--- a/02_AdvancedSageMaker/01_SageMakerProcessing.Rmd
+++ b/02_AdvancedSageMaker/01_SageMakerProcessing.Rmd
@@ -15,6 +15,8 @@ rm(list = ls())
 ## Imports
 ```{r}
 suppressWarnings(library(reticulate))
+path_to_python <- "/opt/python/3.7.7/bin/python"
+use_python(path_to_python)
 sagemaker <- import('sagemaker')
 ```
 


### PR DESCRIPTION
This will remove the microconda installation, and the potential "Error in py_module_import(module, convert = convert) :    ModuleNotFoundError: No module named 'sagemaker'" error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
