### PR TITLE
Update 00_Intro.Rmd

### DIFF
--- a/00_Intro/00_Intro.Rmd
+++ b/00_Intro/00_Intro.Rmd
@@ -78,7 +78,7 @@ containers.
 ```{r}
 # Packages ----
 suppressWarnings(library(reticulate))
-path_to_python <- "/opt/python/3.7.7/bin/python"
+path_to_python <- system("which python", intern = TRUE)
 use_python(path_to_python)
 
 

--- a/00_Intro/00_Intro.Rmd
+++ b/00_Intro/00_Intro.Rmd
@@ -78,6 +78,9 @@ containers.
 ```{r}
 # Packages ----
 suppressWarnings(library(reticulate))
+path_to_python <- "/opt/python/3.7.7/bin/python"
+use_python(path_to_python)
+
 
 # Python packages ----
 sagemaker <- import("sagemaker")


### PR DESCRIPTION
This will remove the microconda installation, and the potential "Error in py_module_import(module, convert = convert) : ModuleNotFoundError: No module named 'sagemaker'" error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
