### PR TITLE
fix: inference container reference on Advanced SageMaker module

### DIFF
--- a/02_AdvancedSageMaker/02_SageMakerTraining.Rmd
+++ b/02_AdvancedSageMaker/02_SageMakerTraining.Rmd
@@ -104,9 +104,9 @@ best_estimator <- tuner$best_estimator()
 
 
 ```{r}
-inference_contianer_uri <- paste(account_id, "dkr.ecr", region, "amazonaws.com/sagemaker-r-inference:1.0", sep=".")
+inference_container_uri <- paste(account_id, "dkr.ecr", region, "amazonaws.com/sagemaker-r-inference:1.0", sep=".")
 
-trained_model <- best_estimator$create_model(name='r-iris-model', role=role, image_uri = container_uri)
+trained_model <- best_estimator$create_model(name='r-iris-model', role=role, image_uri = inference_container_uri)
 endpoint  <- trained_model$deploy(initial_instance_count = 1L,
                                   instance_type = "ml.t2.medium",
                                   serializer = sagemaker$serializers$CSVSerializer(content_type='text/csv'),


### PR DESCRIPTION
*Description of changes:*
The SageMaker Training notebook in the 02_Advanced SageMaker module has an incorrect reference for the training container when deploying the inference endpoint. This commit sets the inference endpoint to use the inference container. Fixes a typo in the variable name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
